### PR TITLE
Improve modal experience

### DIFF
--- a/src/BookSearch/BookResult/BookResult.jsx
+++ b/src/BookSearch/BookResult/BookResult.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect }  from 'react';
 import BookModal from '../../Modal/BookModal';
+import useScrollPosition from '../../hooks/useScrollPosition';
 
 const BookResult = ({ result, setTab, setRefreshBooks }) => {
 	const bookId = result.id;
@@ -9,12 +10,12 @@ const BookResult = ({ result, setTab, setRefreshBooks }) => {
 	const [modalOpen, setModalOpen] = useState(false);
 	const [bookSaveResult, setBookSaveResult] = useState(null);
 
-	useEffect(() => {
+	useScrollPosition(modalOpen);
 
+	useEffect(() => {
 		if (bookSaveResult) {
 			setRefreshBooks(true);
 			setTab("Home");
-			// window.history.replaceState(null, '', window.location.pathname);
 		}
 	}, [bookSaveResult, setRefreshBooks, setTab]);
 

--- a/src/BookSearch/BookResult/BookResult.jsx
+++ b/src/BookSearch/BookResult/BookResult.jsx
@@ -7,10 +7,10 @@ const BookResult = ({ result, setTab, setRefreshBooks }) => {
 	const bookCoverLink = `https://books.google.com/books/content/images/frontcover/${bookId}`;
 	const data = result?.volumeInfo;
 
-	const [modalOpen, setModalOpen] = useState(false);
+	const [isModalOpen, setIsModalOpen] = useState(false);
 	const [bookSaveResult, setBookSaveResult] = useState(null);
 
-	useScrollPosition(modalOpen);
+	useScrollPosition(isModalOpen);
 
 	useEffect(() => {
 		if (bookSaveResult) {
@@ -23,7 +23,7 @@ const BookResult = ({ result, setTab, setRefreshBooks }) => {
 		<li>
 			<div 
 				className='book-cover-button' 
-				onClick={() => setModalOpen(true)}> 
+				onClick={() => setIsModalOpen(true)}> 
 				 <figure>
 					 <div 
 						 id={bookId} 
@@ -31,10 +31,10 @@ const BookResult = ({ result, setTab, setRefreshBooks }) => {
 						</div>
 				 </figure>
 			</div>
-			{ setModalOpen && (
+			{ setIsModalOpen && (
 				<BookModal
-					modalOpen={modalOpen}
-					setModalOpen={setModalOpen}
+					isModalOpen={isModalOpen}
+					setIsModalOpen={setIsModalOpen}
 					setBookSaveResult={setBookSaveResult}
 					bookId={bookId}
 					data={data}

--- a/src/Books/RatingForm/RatingForm.jsx
+++ b/src/Books/RatingForm/RatingForm.jsx
@@ -69,7 +69,7 @@ const RatingForm = ({
 			onSubmit={(event) => saveRating(event)}	
 		>
 			<CloseModalButton 
-				setModalOpen={setRatingFormOpen}
+				setIsModalOpen={setRatingFormOpen}
 				type="rating-form"
 			/>
 			<h3 className='add-rating-title'>Add rating</h3>

--- a/src/Modal/BookModal.jsx
+++ b/src/Modal/BookModal.jsx
@@ -1,11 +1,11 @@
 import Modal from 'react-modal';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import CloseModalButton from './CloseModalButton';
 import './BookModal.scss';
 import { saveBookAsync } from './hooks';
 import { coerceToString } from '../utils';
 
-const BookModal = ({ modalOpen, setModalOpen, setBookSaveResult, bookId, data, bookCoverLink }) => {
+const BookModal = ({ isModalOpen, setIsModalOpen, setBookSaveResult, bookId, data, bookCoverLink }) => {
 	const title = data?.title;
 	const authors = coerceToString(data?.authors || '');
 	const plural = data?.ratingsCount === 1 ? "" : "s" || '';
@@ -23,7 +23,7 @@ const BookModal = ({ modalOpen, setModalOpen, setBookSaveResult, bookId, data, b
 			const result = await saveBookAsync(bookId, username, title, authors, createdAt);
 			if (result === true) {
 				setBookSaveResult(true);
-				setModalOpen(false);
+				setIsModalOpen(false);
 			} else {
 				setBookSaveResult(false);
 			}
@@ -31,22 +31,11 @@ const BookModal = ({ modalOpen, setModalOpen, setBookSaveResult, bookId, data, b
 			console.log(`Error saving book: ${err}`);
 		}
 	};
-		
 
-	useEffect(() => {
-		// blurs background (aside from nav) while the modal is open
-		const bg = document.querySelector("main > div");
-		if (modalOpen) {
-			bg.classList.add('blur-background');
-		} else {
-			bg.classList.remove('blur-background');
-		}
-	}, [modalOpen])
-	
 	return (
 		<Modal
-			isOpen={modalOpen}
-			onRequestClose={() => setModalOpen(false)}
+			isOpen={isModalOpen}
+			onRequestClose={() => setIsModalOpen(false)}
 			contentLabel={title}
 			parentSelector={() => document.querySelector("main")}
 			id={bookId}
@@ -54,7 +43,7 @@ const BookModal = ({ modalOpen, setModalOpen, setBookSaveResult, bookId, data, b
 			overlayClassName={"book-cover-modal"}
 			shouldFocusAfterRender={true}
 		>
-			<CloseModalButton setModalOpen={setModalOpen} />
+			<CloseModalButton setIsModalOpen={setIsModalOpen} />
 			<figure
 				className="book-cover-modal"
 				id={bookId} 

--- a/src/Modal/BookModal.scss
+++ b/src/Modal/BookModal.scss
@@ -96,7 +96,7 @@
 		margin: auto;
 	}
 
-	.close-button-wrapper {
+	.close-button-wrapper:not(.adjust-position) {
 		position: fixed;
 		top: 60px;
 		right: 15px;

--- a/src/Modal/BookModal.scss
+++ b/src/Modal/BookModal.scss
@@ -4,14 +4,12 @@
 }
 
 .ReactModal__Content {
+	// override defaults from ReactModal library
 	position: fixed !important;
 	background-color: black !important;
-	border: 2px solid white !important;
-  width: 90vw;
-  min-width: 400px;
-  margin-left: 2vw;
-  height: 88vh;
-	margin-top: 3vh;
+  min-width: 300px;
+	height: 88vh;
+  margin-top: 3vh;
 }
 
 .book-cover-modal {
@@ -87,4 +85,36 @@
 
 .blur-background {
 	filter: blur(2px);
+}
+
+@media screen and (max-width: 800px) {
+	.ReactModal__Content {
+		inset: 30px 2vw !important;
+	}
+	
+	.book-modal-img-wrapper {
+		margin: auto;
+	}
+
+	.close-button-wrapper {
+		position: fixed;
+		top: 60px;
+		right: 15px;
+	}
+
+	.book-cover-modal {
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		position: relative;
+		margin: 10px;
+	}
+
+	.book-modal-wrapper {
+		display: none;
+	}
+
+	.select-book-button-wrapper {
+		flex-direction: column;
+	}
 }

--- a/src/Modal/BookModal.scss
+++ b/src/Modal/BookModal.scss
@@ -84,7 +84,7 @@
 }
 
 .blur-background {
-	filter: blur(2px);
+	filter: blur(4px);
 }
 
 @media screen and (max-width: 800px) {

--- a/src/Modal/CloseModalButton.jsx
+++ b/src/Modal/CloseModalButton.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 import './BookModal.scss';
 
-const CloseModalButton = ({ setModalOpen, type }) => (
+const CloseModalButton = ({ setIsModalOpen, type }) => (
   <div className={`close-button-wrapper ${type === 'rating-form' && 'adjust-position'}`}>
-    <button className="close-modal" onClick={() => setModalOpen(false)}>
+    <button className="close-modal" onClick={() => setIsModalOpen(false)}>
       x
     </button>
   </div>

--- a/src/hooks/useScrollPosition.js
+++ b/src/hooks/useScrollPosition.js
@@ -1,24 +1,27 @@
 import { useEffect, useRef } from 'react';
 
-const useScrollPosition = (isOpen) => {
+const useScrollPosition = (isModalOpen) => {
   /*
-   This hook freezes the background when a modal is open.
+   This hook freezes and blurs the background when a modal is open.
    It also stores the current scroll position as a ref to ensure
-   it is restored when the modal closes.
+   the scroll position is restored when the modal closes.
   */
   const scrollPosition = useRef(0);
- 
+  
   useEffect(() => {
-    if (isOpen) {
+    const backgroundElement = document.querySelector("main > div");
+    if (isModalOpen) {
       scrollPosition.current = window.scrollY;
       document.documentElement.style.overflow = 'hidden';
       document.body.style.overflow = 'hidden';
+			backgroundElement.classList.add('blur-background');
     } else {
       document.documentElement.style.overflow = '';
       document.body.style.overflow = '';
       window.scrollTo(0, scrollPosition.current);
+			backgroundElement.classList.remove('blur-background');
     }
-  }, [isOpen]);
+  }, [isModalOpen]);
   return;
 }
 

--- a/src/hooks/useScrollPosition.js
+++ b/src/hooks/useScrollPosition.js
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react';
+
+const useScrollPosition = (isOpen) => {
+  /*
+   This hook freezes the background when a modal is open.
+   It also stores the current scroll position as a ref to ensure
+   it is restored when the modal closes.
+  */
+  const scrollPosition = useRef(0);
+ 
+  useEffect(() => {
+    if (isOpen) {
+      scrollPosition.current = window.scrollY;
+      document.documentElement.style.overflow = 'hidden';
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.documentElement.style.overflow = '';
+      document.body.style.overflow = '';
+      window.scrollTo(0, scrollPosition.current);
+    }
+  }, [isOpen]);
+  return;
+}
+
+export default useScrollPosition;


### PR DESCRIPTION
* improve modal experience on mobile
* add a new useScrollPosition hook that freezes and blurs the background when the modal opens

## **Before**

On narrower phones, the user had to scroll horizontally which led to an awkward experience.

<img width="504" height="765" alt="b_before" src="https://github.com/user-attachments/assets/4d7e28bc-7e67-485c-a7d5-8d5b54c20edb" />

______

## **After**

It is now centred correctly on all screen widths, and all elements are visible. The background outside the modal is also frozen.

<img width="507" height="828" alt="aft1" src="https://github.com/user-attachments/assets/c93839f0-2474-496f-8dc7-538233779a04" />

______
The modal view still scrolls vertically when necessary.

<img width="479" height="804" alt="Screenshot 2026-02-15 at 00 14 13" src="https://github.com/user-attachments/assets/3059d9e0-7246-4960-b601-613a578640e1" />

